### PR TITLE
RyleyLink improvement: change extremely aggressive options of sending…

### DIFF
--- a/pump/medtronic/src/main/kotlin/app/aaps/pump/medtronic/comm/MedtronicCommunicationManager.kt
+++ b/pump/medtronic/src/main/kotlin/app/aaps/pump/medtronic/comm/MedtronicCommunicationManager.kt
@@ -109,7 +109,7 @@ class MedtronicCommunicationManager  // This empty constructor must be kept, oth
         if (state !== PumpDeviceState.PumpUnreachable) medtronicPumpStatus.pumpDeviceState = PumpDeviceState.WakingUp
         for (retry in 0..4) {
             aapsLogger.debug(LTag.PUMPCOMM, "isDeviceReachable. Waking pump... " + if (retry != 0) " (retry $retry)" else "")
-            val connected = connectToDevice()
+            val connected = connectToDevice(retry)
             if (connected) return true
             SystemClock.sleep(1000)
         }
@@ -123,14 +123,14 @@ class MedtronicCommunicationManager  // This empty constructor must be kept, oth
         return false
     }
 
-    private fun connectToDevice(): Boolean {
+    private fun connectToDevice(retry: Int): Boolean {
         val state = medtronicPumpStatus.pumpDeviceState
 
         // check connection
         val pumpMsgContent = createPumpMessageContent(RLMessageType.ReadSimpleData) // simple
         val rfSpyResponse = rfspy.transmitThenReceive(
-            RadioPacket(injector, pumpMsgContent), 0.toByte(), 200.toByte(),
-            0.toByte(), 0.toByte(), 25000, 0.toByte()
+            RadioPacket(injector, pumpMsgContent), 0.toByte(), retry.toByte(),
+            0.toByte(), 0.toByte(), 5000, 0.toByte()
         )
         aapsLogger.info(LTag.PUMPCOMM, "wakeup: raw response is " + ByteUtil.shortHexString(rfSpyResponse.raw))
         if (rfSpyResponse.wasTimeout()) {

--- a/pump/rileylink/src/main/java/app/aaps/pump/common/hw/rileylink/RileyLinkCommunicationManager.java
+++ b/pump/rileylink/src/main/java/app/aaps/pump/common/hw/rileylink/RileyLinkCommunicationManager.java
@@ -151,8 +151,8 @@ public abstract class RileyLinkCommunicationManager<T extends RLMessage> {
             aapsLogger.info(LTag.PUMPBTCOMM, "Waking pump...");
 
             byte[] pumpMsgContent = createPumpMessageContent(RLMessageType.ReadSimpleData); // simple
-            RFSpyResponse resp = rfspy.transmitThenReceive(new RadioPacket(injector, pumpMsgContent), (byte) 0, (byte) 200,
-                    (byte) 0, (byte) 0, 25000, (byte) 0);
+            RFSpyResponse resp = rfspy.transmitThenReceive(new RadioPacket(injector, pumpMsgContent), (byte) 0, (byte) 4,
+                    (byte) 0, (byte) 0, 5000, (byte) 0);
             aapsLogger.info(LTag.PUMPBTCOMM, "wakeup: raw response is " + ByteUtil.INSTANCE.shortHexString(resp.getRaw()));
 
             // FIXME wakeUp successful !!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
… 200 commands to pump when waking it up which can cause instability, overload of pump and faster battery drain.

2 methods changed. In wakeUp method decreased count of retries from 200 to 4. In isDeviceReachable method now using retry iteration to first try to ping using single command and then increase number of retries by 1 in each attempt. Also timeouts decreased from 25 to 5 seconds for faster feedback of pump unavailability - no need to big timeout when only 5 requests were sent.

This is a commit without any configuration. Probably in beta we can add boolean enabler or even move number of retries and timeout value as experimental parameters to be able to play with them and find best values.